### PR TITLE
v0.1.3

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,0 +1,50 @@
+{% set name = "streamlit-image-coordinates" %}
+{% set version = "0.1.3" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/streamlit-image-coordinates-{{ version }}.tar.gz
+  sha256: d0218bf2f575ce8553f24f6bc286f347f85f6dd2f36c96dc04b10dd6b74e27ca
+
+build:
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  number: 0
+  # s390x missing streamlit
+  skip: true  # [py<37 or s390x]
+
+requirements:
+  host:
+    - python
+    - pip
+    - setuptools
+    - wheel
+  run:
+    - python
+    - streamlit >=1.2
+    - jinja2
+
+test:
+  imports:
+    - streamlit_image_coordinates
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://github.com/blackary/streamlit-image-coordinates/
+  dev_url: https://github.com/blackary/streamlit-image-coordinates/
+  doc_url: https://github.com/blackary/streamlit-image-coordinates/blob/main/README.md
+  summary: Streamlit component that displays an image and returns the coordinates when you click on it
+  description: |
+    Streamlit component that displays an image and returns the coordinates when you click on it
+  license: MIT
+  license_file: LICENSE
+  license_family: MIT
+
+extra:
+  recipe-maintainers:
+    - ELundby45


### PR DESCRIPTION
# streamlit-image-coordinates v0.1.3

`streamlit-extras` -> `markdownlit` -> `streamlit-image-coordinates`

upstream: https://github.com/blackary/streamlit-image-coordinates/tree/main

## Notes
- s390x missing streamlit so it is skipped.
- This is a brand new feedstock
- For Snowflake